### PR TITLE
Typo ("langs = {}" not "lang = {}")

### DIFF
--- a/lua/classes/classes/class_shooter.lua
+++ b/lua/classes/classes/class_shooter.lua
@@ -16,7 +16,7 @@ CLASS.AddClass("SHOOTER", {
 			ply:RemoveArmor(60)
 		end
 	end,
-	lang = {
+	langs = {
 		name = {
 			English = "Shooter"
 		},


### PR DESCRIPTION
Hey-o, champs.

Looks like you're got a typo here. "langs" is effective, but "lang" won't do nothin'.

Thought I'd better raise it, since this class is linked as the example from "README.mc" in TTT-2 / TTTC.

Cheerio!